### PR TITLE
feat: 리뷰 기능 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -224,6 +224,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2120,6 +2121,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2304,6 +2306,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.8.tgz",
       "integrity": "sha512-bbsOqwld/GdBfiRNc4nnjyWWENDEicq4SH+R5AuYatvf++vf1x5JIsHB1i1KtfZMD3eRte0D4K9WXuAYil6XAg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "file-type": "21.0.0",
         "iterare": "1.2.1",
@@ -2363,6 +2366,7 @@
       "integrity": "sha512-7riWfmTmMhCJHZ5ZiaG+crj4t85IPCq/wLRuOUSigBYyFT2JZj0lVHtAdf4Davp9ouNI8GINBDt9h9b5Gz9nTw==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -2423,6 +2427,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.8.tgz",
       "integrity": "sha512-rL6pZH9BW7BnL5X2eWbJMtt86uloAKjFgyY5+L2UkizgfEp7rgAs0+Z1z0BcW2Pgu5+q8O7RKPNyHJ/9ZNz/ZQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cors": "2.8.5",
         "express": "5.1.0",
@@ -2853,6 +2858,7 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -2973,6 +2979,7 @@
       "integrity": "sha512-Bo45YKIjnmFtv6I1TuC8AaHBbqXtIo+Om5fE4QiU1Tj8QR/qt+8O3BAtOimG5IFmwaWiPmB3Mv3jtYzBA4Us2A==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3124,6 +3131,7 @@
       "integrity": "sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.2",
         "@typescript-eslint/types": "8.46.2",
@@ -3806,6 +3814,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3855,6 +3864,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4296,6 +4306,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -4512,6 +4523,7 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -4559,13 +4571,15 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/class-validator": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.2.tgz",
       "integrity": "sha512-3kMVRF2io8N8pY1IFIXlho9r8IPUUIfHe2hYVtiebvAzU2XeQFXTv+XI4WX+TnXmtwXMDcjngcpkiPM0O9PvLw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/validator": "^13.11.8",
         "libphonenumber-js": "^1.11.1",
@@ -5267,6 +5281,7 @@
       "integrity": "sha512-iy2GE3MHrYTL5lrCtMZ0X1KLEKKUjmK0kzwcnefhR66txcEmXZD2YWgR5GNdcEwkNx3a0siYkSvl0vIC+Svjmg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5327,6 +5342,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -6665,6 +6681,7 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -8361,6 +8378,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -8618,6 +8636,7 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -8818,7 +8837,8 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -8949,6 +8969,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -9670,6 +9691,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -9991,6 +10013,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -10151,6 +10174,7 @@
       "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.27.tgz",
       "integrity": "sha512-pNV1bn+1n8qEe8tUNsNdD8ejuPcMAg47u2lUGnbsajiNUr3p2Js1XLKQjBMH0yMRMDfdX8T+fIRejFmIwy9x4A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
         "ansis": "^3.17.0",
@@ -10380,6 +10404,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10739,7 +10764,6 @@
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -10758,7 +10782,6 @@
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -10772,7 +10795,6 @@
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -10787,7 +10809,6 @@
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -10797,8 +10818,7 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/webpack/node_modules/mime-db": {
       "version": "1.52.0",
@@ -10806,7 +10826,6 @@
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -10817,7 +10836,6 @@
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -10831,7 +10849,6 @@
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",

--- a/src/domain/review/dto/create-review.dto.ts
+++ b/src/domain/review/dto/create-review.dto.ts
@@ -1,1 +1,19 @@
-export class CreateReviewDto {}
+import { IsNumber, Max, Min, IsNotEmpty, IsUUID, IsOptional } from 'class-validator';
+
+export class CreateReviewDto {
+  @IsNumber({ maxDecimalPlaces: 1 }) // 소수점 1자리까지만 허용
+  @Min(0)                            // 최솟값 0.0
+  @Max(5)                            // 최댓값 5.0
+  rating: number;                    // 필수: 평점
+
+  @IsNotEmpty()                      // 빈 문자열 금지
+  content: string;                   // 필수: 리뷰 본문
+
+  @IsOptional()                      // 게시글 연결은 선택
+  @IsUUID()                          // 있을 경우 UUID 형식
+  postId?: string;                   // 옵션: 게시글 ID
+
+  @IsUUID()                          // 필수: 대상 유저 UUID
+  revieweeId: string;                // 리뷰 대상자
+
+}

--- a/src/domain/review/dto/update-review.dto.ts
+++ b/src/domain/review/dto/update-review.dto.ts
@@ -1,4 +1,0 @@
-import { PartialType } from '@nestjs/mapped-types';
-import { CreateReviewDto } from './create-review.dto';
-
-export class UpdateReviewDto extends PartialType(CreateReviewDto) {}

--- a/src/domain/review/entities/review.entity.ts
+++ b/src/domain/review/entities/review.entity.ts
@@ -1,25 +1,33 @@
-import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+// src/domain/review/entities/review.entity.ts
+import { Column, Entity, ManyToOne } from 'typeorm';
 import { Post } from '../../post/entities/post.entity';
 import { Users } from '../../users/entities/users.entity';
 import { BaseTimestampEntity } from '../../../base.entity';
 
-@Entity('review', { schema: 'public' })
+// NUMERIC(10,1)을 number로 쓰기 위한 transformer
+const decimalToNumber = {
+  to: (v?: number) => v,
+  from: (v?: string | null) => (v == null ? null : Number(v)),
+};
+
+@Entity({ name: 'review', schema: 'public' })
 export class Review extends BaseTimestampEntity {
-  @Column({ type: 'numeric', name: 'rating', precision: 2, scale: 1 })
-  rating: string;
+  // ⛔ id는 BaseTimestampEntity에 이미 있으므로 여기선 선언하지 않습니다.
 
-  @Column({ type: 'text', name: 'content' })
-  content: string;
+  @ManyToOne(() => Post, { nullable: true, onDelete: 'SET NULL' })
+  post?: Post | null;
 
-  @ManyToOne(() => Post, { onDelete: 'SET NULL' })
-  @JoinColumn([{ name: 'post_id', referencedColumnName: 'id' }])
-  post: Post;
+  @ManyToOne(() => Users, { nullable: false, onDelete: 'RESTRICT' })
+  reviewer: Users;
 
-  @ManyToOne(() => Users, { onDelete: 'RESTRICT' })
-  @JoinColumn([{ name: 'reviewee_id', referencedColumnName: 'id' }])
+  @ManyToOne(() => Users, { nullable: false, onDelete: 'RESTRICT' })
   reviewee: Users;
 
-  @ManyToOne(() => Users, { onDelete: 'RESTRICT' })
-  @JoinColumn([{ name: 'reviewer_id', referencedColumnName: 'id' }])
-  reviewer: Users;
+  @Column({ type: 'numeric', precision: 10, scale: 1, transformer: decimalToNumber })
+  rating: number; // 0.0 ~ 5.0
+
+  @Column({ type: 'text' })
+  content: string;
+
+  // created_at은 BaseTimestampEntity 쪽에서 제공(없다면 @CreateDateColumn 추가)
 }

--- a/src/domain/review/review.controller.ts
+++ b/src/domain/review/review.controller.ts
@@ -1,42 +1,21 @@
-import {
-  Controller,
-  Get,
-  Post,
-  Body,
-  Patch,
-  Param,
-  Delete,
-} from '@nestjs/common';
+// review.controller.ts
+import { Controller, Post, Body, Req /*, UseGuards*/ } from '@nestjs/common';
 import { ReviewService } from './review.service';
 import { CreateReviewDto } from './dto/create-review.dto';
-import { UpdateReviewDto } from './dto/update-review.dto';
+// import { JwtAuthGuard } from '../auth/guards/jwt.guard'; // 인증이 준비되어 있다면 사용
 
-@Controller('review')
+@Controller('reviews') // 기본 경로: /reviews
 export class ReviewController {
-  constructor(private readonly reviewService: ReviewService) {}
+  // 서비스 주입(생성자 주입)
+  constructor(private readonly service: ReviewService) {}
 
-  @Post()
-  create(@Body() createReviewDto: CreateReviewDto) {
-    return this.reviewService.create(createReviewDto);
-  }
-
-  @Get()
-  findAll() {
-    return this.reviewService.findAll();
-  }
-
-  @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.reviewService.findOne(+id);
-  }
-
-  @Patch(':id')
-  update(@Param('id') id: string, @Body() updateReviewDto: UpdateReviewDto) {
-    return this.reviewService.update(+id, updateReviewDto);
-  }
-
-  @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.reviewService.remove(+id);
+  // @UseGuards(JwtAuthGuard) // JWT 인증을 사용할 경우 활성화
+  @Post() // POST /reviews
+  async create(@Body() dto: CreateReviewDto, @Req() req: any) {
+    // reviewerId는 인증이 있다면 토큰에서 추출하는 것을 권장
+    // 인증이 준비되지 않았다면 임시로 body의 reviewerId를 허용할 수도 있음(지양)
+    const reviewerId = req.user?.id ?? dto['reviewerId']; // 인증 도입 시 dto['reviewerId'] 제거 권장
+    // 서비스에 생성 요청을 위임
+    return this.service.create(dto, reviewerId);
   }
 }

--- a/src/domain/review/review.module.ts
+++ b/src/domain/review/review.module.ts
@@ -1,9 +1,17 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Review } from './entities/review.entity';
+import { Post } from '../post/entities/post.entity';
+import { Users } from '../users/entities/users.entity';
 import { ReviewService } from './review.service';
 import { ReviewController } from './review.controller';
 
 @Module({
-  controllers: [ReviewController],
-  providers: [ReviewService],
+  imports: [
+    // TypeORM 리포지토리를 DI로 사용하기 위해 forFeature 등록
+    TypeOrmModule.forFeature([Review, Post, Users]),
+  ],
+  providers: [ReviewService],      // 서비스 프로바이더 등록
+  controllers: [ReviewController], // 라우팅 담당 컨트롤러 등록
 })
 export class ReviewModule {}

--- a/src/domain/review/review.service.ts
+++ b/src/domain/review/review.service.ts
@@ -1,26 +1,54 @@
-import { Injectable } from '@nestjs/common';
+// src/domain/review/review.service.ts
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { DataSource, Repository } from 'typeorm';
+import { Review } from './entities/review.entity';
+import { Post } from '../post/entities/post.entity';
+import { Users } from '../users/entities/users.entity';
 import { CreateReviewDto } from './dto/create-review.dto';
-import { UpdateReviewDto } from './dto/update-review.dto';
 
 @Injectable()
 export class ReviewService {
-  create(createReviewDto: CreateReviewDto) {
-    return 'This action adds a new review';
-  }
+  constructor(
+    @InjectRepository(Review) private readonly reviewRepo: Repository<Review>,
+    @InjectRepository(Post) private readonly postRepo: Repository<Post>,
+    @InjectRepository(Users) private readonly userRepo: Repository<Users>,
+    private readonly ds: DataSource,
+  ) {}
 
-  findAll() {
-    return `This action returns all review`;
-  }
+  async create(dto: CreateReviewDto, reviewerId?: string) {
+    if (!reviewerId) throw new ForbiddenException('리뷰어 식별이 필요합니다.');
+    if (reviewerId === dto.revieweeId) {
+      throw new BadRequestException('본인을 평가할 수 없습니다.');
+    }
 
-  findOne(id: number) {
-    return `This action returns a #${id} review`;
-  }
+    const reviewee = await this.userRepo.findOne({ where: { id: dto.revieweeId } });
+    if (!reviewee) throw new NotFoundException('리뷰 대상 사용자가 없습니다.');
 
-  update(id: number, updateReviewDto: UpdateReviewDto) {
-    return `This action updates a #${id} review`;
-  }
+    let post: Post | null = null;
+    if (dto.postId) {
+      post = await this.postRepo.findOne({ where: { id: dto.postId } });
+      if (!post) throw new NotFoundException('게시글이 없습니다.');
+      // TODO: reviewer/reviewee가 해당 post의 참여자인지 검증이 필요하면 여기서 확인
+    }
 
-  remove(id: number) {
-    return `This action removes a #${id} review`;
+    const entity = this.reviewRepo.create({
+      rating: dto.rating,
+      content: dto.content,
+      post: post ?? null,
+      reviewer: { id: reviewerId } as Users,
+      reviewee,
+    });
+
+    const saved = await this.ds.transaction(async (manager) => {
+      return manager.getRepository(Review).save(entity);
+    });
+
+    return { id: saved.id };
   }
 }


### PR DESCRIPTION
## 개요 (Summary)

* 프론트엔드 `/review` 페이지에서 사용할 **리뷰 생성 API(POST /reviews)**를 신규 도입했습니다.
* 수정/삭제/조회는 지원하지 않고 **생성만** 처리합니다.
* DTO 유효성, 숫자 변환(transformer), 도메인 규칙(자기평가 금지/존재 검증)까지 포함했습니다.

---

## 배경 (Context)

* FE 라우팅 명세에 따라 리뷰는 `/review`에서만 작성되며, 백엔드는 DB에 **저장만** 수행합니다.
* JWT는다른 담당자가 연동 예정으로, 추후 수정이 필요합니다.

---

## 주요 변경 사항

* **Entity**

  * `review.entity.ts`

    * `rating: numeric(10,1)` ↔︎ 코드상 `number` 사용을 위한 `transformer` 적용
    * `post?: Post | null`(nullable, `onDelete: SET NULL`)
    * `reviewer: Users` / `reviewee: Users`(`onDelete: RESTRICT`)
    * 베이스 엔티티의 `id` 사용(자식에서 재선언 제거)로 TS 경고(TS2612) 해결
    * `ManyToOne(() => Post)`는 단방향 사용(역방향 필드가 없을 때 오류 방지)

* **DTO**

  * `create-review.dto.ts`

    * `rating`(0.0~5.0, 소수 1자리), `content`(필수), `revieweeId`(UUID), `postId?`(UUID)
    * **개발용 임시**: `reviewerId?`(JWT 연동 전 테스트용, 추후 제거 예정)

* **Controller**

  * `review.controller.ts`

    * `POST /reviews` 단일 엔드포인트
    * `const reviewerId = req.user?.id ?? dto.reviewerId;` (JWT 도입 시 `req.user.id`만 사용하도록 수정 예정)

* **Service**

  * `review.service.ts`

    * 권한/도메인 검증:

      * reviewer 식별 필수(없으면 403), 자기평가 금지(400)
      * `reviewer`, `reviewee`, `(옵션)post` **존재 확인**(없으면 404)
    * 트랜잭션으로 안전 저장
    * (에러 가독성) DB 제약 위반 시 4xx로 매핑할 수 있도록 구조화

* **Module**

  * `review.module.ts`: TypeORM forFeature 등록(Review, Post, Users), Controller/Service 바인딩

---

## API 스펙

* **POST /reviews**

  * Request Body

    ```json
    {
      "rating": 4.5,
      "content": "문장",
      "revieweeId": "UUID",
      "postId": "UUID (optional)",
      "reviewerId": "UUID (개발용 임시, 추후 제거)"
    }
    ```
  * Response

    ```json
    { "id": "생성된 리뷰 UUID" }
    ```

