### PR TITLE
Feat: 게시글 참여 상태 변경 API 추가

### DIFF
--- a/src/domain/post-participation/dto/update-post-participation.dto.ts
+++ b/src/domain/post-participation/dto/update-post-participation.dto.ts
@@ -1,4 +1,14 @@
-import { PartialType } from '@nestjs/mapped-types';
-import { CreatePostParticipationDto } from './create-post-participation.dto';
+import { IsEnum, IsNotEmpty } from 'class-validator';
 
-export class UpdatePostParticipationDto extends PartialType(CreatePostParticipationDto) {}
+export enum PostParticipationStatus {
+  APPROVED = '승인',
+  REJECTED = '거절',
+}
+
+export class UpdatePostParticipationDto {
+  @IsNotEmpty({ message: '상태를 입력해주세요.' })
+  @IsEnum(PostParticipationStatus, {
+    message: '상태는 "승인" 또는 "거절"만 가능합니다.',
+  })
+  status: PostParticipationStatus;
+}

--- a/src/domain/post-participation/post-participation.controller.ts
+++ b/src/domain/post-participation/post-participation.controller.ts
@@ -1,9 +1,11 @@
 import {
+  Body,
   Controller,
   HttpCode,
   Get,
   HttpStatus,
   Param,
+  Patch,
   ParseUUIDPipe,
   Post,
   Req,
@@ -13,6 +15,7 @@ import { AuthGuard } from '@nestjs/passport';
 import { Request } from 'express';
 import { PostParticipationService } from './post-participation.service';
 import { PostParticipationResponseDto } from './dto/post-participation-response.dto';
+import { UpdatePostParticipationDto } from './dto/update-post-participation.dto';
 
 @Controller('posts/:postId/participations')
 export class PostParticipationController {
@@ -40,5 +43,23 @@ export class PostParticipationController {
     @Param('postId', ParseUUIDPipe) postId: string,
   ): Promise<PostParticipationResponseDto[]> {
     return this.postParticipationService.getParticipationsForPost(postId);
+  }
+
+  @Patch(':participationId')
+  @UseGuards(AuthGuard('jwt'))
+  @HttpCode(HttpStatus.OK)
+  updateParticipationStatus(
+    @Param('postId', ParseUUIDPipe) postId: string,
+    @Param('participationId', ParseUUIDPipe) participationId: string,
+    @Req() req: Request & { user: { id: string } },
+    @Body() updatePostParticipationDto: UpdatePostParticipationDto,
+  ): Promise<PostParticipationResponseDto> {
+    const authorId = req.user.id;
+    return this.postParticipationService.updateParticipationStatus(
+      postId,
+      participationId,
+      authorId,
+      updatePostParticipationDto,
+    );
   }
 }


### PR DESCRIPTION
- 게시글 참여 상태를 '승인' 또는 '거절'로 업데이트하는 기능 구현.
- 유효성 검증 및 에러 메시지를 포함한 DTO 작성.
- 작성자 권한 검증 로직 추가.
- 컨트롤러 및 서비스 메소드에 상태 변경 관련 로직 반영.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 게시물 참여 상태 업데이트 API 엔드포인트 추가
  * 상태는 "승인" 또는 "거절"로만 설정 가능
  * 게시물 작성자만 상태 변경 가능
  * 필수 입력값 및 형식 검증 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->