### PR TITLE
Fix: poiconnection을 가져올 때 cache에 안 들리는 버그 수정

### DIFF
--- a/src/domain/workspace/service/poi-connection-cache.service.ts
+++ b/src/domain/workspace/service/poi-connection-cache.service.ts
@@ -32,6 +32,20 @@ export class PoiConnectionCacheService {
     }
   }
 
+  async getPoiConnectionsByPlanDayList(
+    planDayIds: string[],
+  ): Promise<CachePoiConnection[]> {
+    const cachedPoiConnections: CachePoiConnection[] = [];
+    for (const planDayId of planDayIds) {
+      const cached = await this.getPoiConnections(planDayId);
+      if (cached.length > 0) {
+        cachedPoiConnections.push(...cached);
+      }
+    }
+
+    return cachedPoiConnections;
+  }
+
   async getPoiConnection(
     planDayId: string,
     poiConnectionId: string,

--- a/src/domain/workspace/service/poi-connection.service.ts
+++ b/src/domain/workspace/service/poi-connection.service.ts
@@ -56,22 +56,20 @@ export class PoiConnectionService {
      * planDay에 맞는 poiConnection들을 찾고
      * persistedConnections: planDay에 맞는 poiConnection들
      */
-    // Todo : 캐시에 찾고 없으면 load
-    // const cached =
-    //   await this.poiConnectionCacheService.getAllPoiConnections(workspaceId);
-    // if (cached.length > 0) {
-    //   return cached;
-    // }
-
-    // const planDays: PlanDay[] =
-    //   await this.planDayService.getWorkspacePlanDays(workspaceId);
-    //const planDayIds = planDays.map((planDay) => planDay.id);
-
     const planDayIds =
       await this.planDayService.getWorkspacePlanDayIds(workspaceId);
 
     if (planDayIds.length === 0) {
       return {};
+    }
+
+    const cachedPoiConnections: CachePoiConnection[] =
+      await this.poiConnectionCacheService.getPoiConnectionsByPlanDayList(
+        planDayIds,
+      );
+
+    if (cachedPoiConnections.length > 0) {
+      return buildGroupedPoiConnectionsDto(planDayIds, cachedPoiConnections);
     }
 
     // Todo: 성능 이슈 보임 => 나중에 최적화 시키기


### PR DESCRIPTION
poiconnection을 가져올 때 cache에 안 들리는 버그 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 여러 계획일에 대한 관심지점 연결 정보를 일괄 조회하는 기능이 추가되었습니다.

* **성능 개선**
  * 관심지점 연결 데이터의 로드 시간이 개선되었습니다. 이전에 요청했던 데이터는 더 빠르게 재사용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->