### PR TITLE
Fix: 매너온도 null 일수 있는거 지움

### DIFF
--- a/src/domain/profile/matching.service.ts
+++ b/src/domain/profile/matching.service.ts
@@ -554,7 +554,7 @@ export class MatchingService {
         candidate.profile = {
           nickname: profile.nickname ?? '',
           // mbtiTypes: profile.mbtiTypes ?? null,
-          mannerTemperature: profile.mannerTemperature ?? null,
+          mannerTemperature: profile.mannerTemperature,
           profileImageId: profile.profileImage?.id ?? null,
         };
         return {


### PR DESCRIPTION
null 일 수 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 프로필 매칭에서 성격 온도 값이 보다 정확하게 처리되도록 개선했습니다. 이전에는 미정의된 값이 부정확하게 처리되었으나, 이제 프로필 데이터가 올바르게 반영됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->