### PR TITLE
Feat: focus이벤트에서 데이터 가져올 때 인기도 점수도 가져오도록 수정

### DIFF
--- a/src/domain/place/dto/get-places-res.dto.ts
+++ b/src/domain/place/dto/get-places-res.dto.ts
@@ -9,6 +9,7 @@ export class GetPlacesResDto {
   image_url?: string;
   longitude: number;
   latitude: number;
+  popularityScore?: number; // 인기도 점수 (POI_MARK + POI_SCHEDULE 이벤트 수)
 
   constructor(
     id: string,
@@ -19,6 +20,7 @@ export class GetPlacesResDto {
     latitude: number,
     summary?: string,
     image_url?: string,
+    popularityScore?: number,
   ) {
     this.id = id;
     this.category = category;
@@ -28,9 +30,10 @@ export class GetPlacesResDto {
     this.image_url = image_url;
     this.longitude = longitude;
     this.latitude = latitude;
+    this.popularityScore = popularityScore;
   }
 
-  static from(place: Place) {
+  static from(place: Place, popularityScore?: number) {
     return new GetPlacesResDto(
       place.id,
       place.category, // DB변경 전 임시
@@ -40,6 +43,7 @@ export class GetPlacesResDto {
       place.latitude,
       place.summary,
       place.image_url,
+      popularityScore,
     );
   }
 }

--- a/src/domain/workspace/gateway/poi.gateway.ts
+++ b/src/domain/workspace/gateway/poi.gateway.ts
@@ -439,8 +439,8 @@ export class PoiGateway {
       const roomName = this.getPoiRoomName(data.workspaceId);
       this.validateRoomAuth(roomName, socket);
 
-      // 지도 bounds 내의 장소 목록 가져오기
-      const places = await this.placeService.getPlacesInBounds({
+      // 지도 bounds 내의 장소 목록 (인기도 점수 포함)
+      const places = await this.placeService.getPlacesInBoundsWithPopularity({
         southWestLatitude: data.southWestLatitude,
         southWestLongitude: data.southWestLongitude,
         northEastLatitude: data.northEastLatitude,
@@ -453,9 +453,8 @@ export class PoiGateway {
         userName: data.userName,
         places,
       });
-      // TODO : Focus는 특정 클라이언트에만 보내주고 프론트에서 버튼이나 뭐 누르면 그 사용자의 Focus로 가는거
       this.logger.debug(
-        `[PLACE_FOCUS] User ${data.userName} focused, returned ${places.length} places in bounds`,
+        `[PLACE_FOCUS] User ${data.userName} focused, returned ${places.length} places with popularity scores`,
       );
     } catch (error) {
       this.logger.error(


### PR DESCRIPTION
focus이벤트에서 데이터 가져올 때 인기도 점수도 가져오도록 수정
- 단순 Place만 가져오는게 아니라 UserBehaviorEvents테이블과 Join을 통한 인기도 점수를 포함한 Place 추가 
- 모든 데이터마다 인기도 점수 포함되야 하므로 한 번에 조회 (프론트에서 카테고리별 필터링 시 TopN)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 장소 검색 결과에 인기도 점수가 추가되었습니다. 사용자는 이제 각 장소의 인기도 정보를 확인하여 더 인기 있는 장소를 쉽게 파악하고 선택할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->