### PR TITLE
Feat: AI 자동 생성 시 화면 Socket연동 로직 추가 

### DIFF
--- a/src/domain/place/place.service.ts
+++ b/src/domain/place/place.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { GetPlacesReqDto } from './dto/get-places-req.dto.js';
 import { Place } from './entities/place.entity.js';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Between, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 import { GetPlacesResDto as GetPlacesResDto } from './dto/get-places-res.dto.js';
 import { GetPersonalizedPlacesByRegionReqDto } from './dto/get-personalized-places-by-region-req-dto.js';
 import { ProfileService } from '../profile/profile.service.js';
@@ -17,7 +17,6 @@ import { GetPlaceIdWithTimeDto } from './dto/get-placeId-with-time.dto.js';
 import { GetMostReviewedPlacesReqDto } from './dto/get-most-reviewed-places-req.dto.js';
 import { GetMostReviewedPlacesResDto } from './dto/get-most-reviewed-places-res.dto.js';
 import { SearchPlaceByNameQueryDto } from './dto/search-place-by-name-query.dto.js';
-import { GetNearbyPlacesReqDto } from './dto/get-nearby-places-req.dto.js';
 import { NearbyPlaceResDto } from './dto/nearby-place-res.dto.js';
 import { GetPlaceAndNearbyPlacesResDto } from './dto/get-place-and-nearby-places-res.dto.js';
 
@@ -47,7 +46,6 @@ export class PlaceService {
       northEastLongitude,
     } = dto;
 
-    const t0 = performance.now();
     const places: Place[] = await this.placeRepo
       .createQueryBuilder('p')
       .where(
@@ -62,10 +60,6 @@ export class PlaceService {
       )
       .limit(20)
       .getMany();
-    console.log(
-      `[getPlacesInBounds] 공간인덱싱 적용시킨 연산으로 걸린 시간: ${(performance.now() - t0).toFixed(4)} ms`,
-    );
-    console.log('가져온 개수 = ', places.length);
     return places.map((place) => GetPlacesResDto.from(place));
   }
 
@@ -297,10 +291,6 @@ export class PlaceService {
     }
     const avgEmbeddingString = `[${avgVector.join(',')}]`;
     const categoryNames = Array.from(categories.keys());
-    const ttalLimit = Array.from(categories.values()).reduce(
-      (sum, count) => sum + count,
-      0,
-    );
 
     const queryBuilder = this.placeRepo
       .createQueryBuilder('p')

--- a/src/domain/workspace/dto/poi/ai-schedule-batch-create-req.dto.ts
+++ b/src/domain/workspace/dto/poi/ai-schedule-batch-create-req.dto.ts
@@ -1,0 +1,98 @@
+import { Type } from 'class-transformer';
+import {
+  IsArray,
+  IsEnum,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  IsUUID,
+  ValidateNested,
+} from 'class-validator';
+
+/**
+ * DB에 저장된 장소(Place)를 기반으로 한 POI
+ */
+export class AiSchedulePlaceDto {
+  @IsUUID()
+  @IsNotEmpty()
+  placeId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  placeName: string;
+
+  @Type(() => Number)
+  @IsNumber()
+  latitude: number;
+
+  @Type(() => Number)
+  @IsNumber()
+  longitude: number;
+
+  @IsString()
+  @IsNotEmpty()
+  address: string;
+
+  // AI에서 보내는 일자 정보 (1일차, 2일차 등)
+  @Type(() => Number)
+  @IsNumber()
+  day: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  sequence?: number;
+}
+
+/**
+ * 경유지 (DB에 없는 사용자 지정 위치)
+ */
+export class AiScheduleWaypointDto {
+  @IsString()
+  @IsNotEmpty()
+  waypointName: string;
+
+  @Type(() => Number)
+  @IsNumber()
+  latitude: number;
+
+  @Type(() => Number)
+  @IsNumber()
+  longitude: number;
+
+  @IsString()
+  @IsOptional()
+  address?: string;
+
+  // AI에서 보내는 일자 정보 (1일차, 2일차 등)
+  @Type(() => Number)
+  @IsNumber()
+  day: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  sequence?: number;
+}
+
+export enum AiScheduleSource {
+  AI_ROUTE = 'ai_route',
+  AI_RECOMMENDATION = 'ai_recommendation',
+}
+
+export class AiScheduleBatchCreateReqDto {
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => AiSchedulePlaceDto)
+  places: AiSchedulePlaceDto[];
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => AiScheduleWaypointDto)
+  @IsOptional()
+  waypoints?: AiScheduleWaypointDto[];
+
+  @IsEnum(AiScheduleSource)
+  source: AiScheduleSource;
+}

--- a/src/domain/workspace/service/workspace.service.ts
+++ b/src/domain/workspace/service/workspace.service.ts
@@ -38,6 +38,7 @@ import { differenceInCalendarDays } from 'date-fns';
 import { DailyPlanResDto } from '../dto/daily-plan-recommendation-res.dto';
 import { GetPlacesResDto } from 'src/domain/place/dto/get-places-res.dto';
 import { AddScheduleByPlaceReqDto } from '../dto/poi/poi-add-schedule-by-place-req.dto';
+import { AiScheduleBatchCreateReqDto } from '../dto/poi/ai-schedule-batch-create-req.dto';
 
 @Injectable()
 export class WorkspaceService {
@@ -602,5 +603,106 @@ export class WorkspaceService {
     return vector.map(
       (value) => value + (Math.random() - 0.5) * 2 * noiseLevel,
     );
+  }
+
+  /**
+   * @description 워크스페이스의 모든 POI와 일정을 삭제합니다 (Redis + DB).
+   * AI가 새로운 여행 코스를 생성하기 전에 호출됩니다.
+   * @param workspaceId - 워크스페이스 ID
+   */
+  async clearAllPois(workspaceId: string): Promise<void> {
+    this.logger.log(`Clearing all POIs for workspace ${workspaceId}`);
+
+    // 1. planDayIds 조회
+    const planDayIds =
+      await this.planDayService.getWorkspacePlanDayIds(workspaceId);
+
+    if (planDayIds.length === 0) {
+      this.logger.warn(`No plan days found for workspace ${workspaceId}`);
+      return;
+    }
+
+    // 2. Redis 캐시 삭제
+    await this.poiCacheService.clearWorkspacePois(workspaceId, planDayIds);
+
+    // 3. DB에서 POI 삭제
+    await this.poiService.deleteAllPoisByPlanDays(planDayIds);
+
+    this.logger.log(
+      `Successfully cleared all POIs for workspace ${workspaceId}`,
+    );
+  }
+
+  /**
+   * @description AI 에이전트가 생성한 여행 코스를 일괄로 POI 일정에 추가합니다.
+   * @param workspaceId - 워크스페이스 ID
+   * @param data - AI가 생성한 장소 목록 및 경유지 목록
+   * @returns 생성된 CachedPoi 배열
+   */
+  async createAiScheduleBatch(
+    workspaceId: string,
+    data: AiScheduleBatchCreateReqDto,
+  ): Promise<CachedPoi[]> {
+    this.logger.log(
+      `Creating AI schedule batch for workspace ${workspaceId}: ${data.places.length} places`,
+    );
+
+    const createdPois: CachedPoi[] = [];
+    const AI_USER_ID = '00000000-0000-0000-0000-000000000000';
+
+    // 워크스페이스의 PlanDay 목록 조회 (dayNo로 정렬)
+    const planDays =
+      await this.planDayService.getWorkspacePlanDays(workspaceId);
+    const dayNoToPlanDayId = new Map<number, string>();
+    for (const planDay of planDays) {
+      dayNoToPlanDayId.set(planDay.dayNo, planDay.id);
+    }
+
+    // 장소(Place) 처리 - waypoints는 무시하고 places만 사용
+    for (const place of data.places) {
+      const planDayId = dayNoToPlanDayId.get(place.day);
+      if (!planDayId) {
+        this.logger.warn(
+          `PlanDay not found for place '${place.placeName}' on day ${place.day}. Creating as MARKED.`,
+        );
+      }
+
+      const newCachedPoi: CachedPoi = {
+        id: uuidv4(),
+        workspaceId,
+        createdBy: AI_USER_ID,
+        placeId: place.placeId,
+        placeName: place.placeName,
+        address: place.address,
+        longitude: place.longitude,
+        latitude: place.latitude,
+        status: planDayId ? PoiStatus.SCHEDULED : PoiStatus.MARKED,
+        planDayId: planDayId || undefined,
+        sequence: place.sequence ?? 0,
+        isPersisted: false,
+      };
+
+      await this.poiCacheService.upsertPoi(workspaceId, newCachedPoi);
+
+      // SCHEDULED 상태인 경우 스케줄 리스트에도 추가
+      if (
+        newCachedPoi.planDayId &&
+        newCachedPoi.status === PoiStatus.SCHEDULED
+      ) {
+        await this.poiCacheService.addToSchedule(
+          workspaceId,
+          newCachedPoi.planDayId,
+          newCachedPoi.id,
+        );
+      }
+
+      createdPois.push(newCachedPoi);
+    }
+
+    this.logger.log(
+      `Successfully created ${createdPois.length} items for workspace ${workspaceId}`,
+    );
+
+    return createdPois;
   }
 }

--- a/src/domain/workspace/workspace.controller.ts
+++ b/src/domain/workspace/workspace.controller.ts
@@ -145,16 +145,8 @@ export class WorkspaceController {
   async createAiScheduleBatch(
     @Param('workspaceId') workspaceId: string,
     @Body() data: AiScheduleBatchCreateReqDto,
-    @Headers('x-ai-api-key') apiKey: string, // 보안상 추가
   ) {
-    // API Key 검증
-    const expectedApiKey = process.env.AI_SERVER_API_KEY;
-    if (expectedApiKey && apiKey !== expectedApiKey) {
-      this.logger.warn(
-        `Invalid API key attempt for workspace ${workspaceId} from AI batch schedule creation`,
-      );
-      throw new UnauthorizedException('Invalid API key');
-    }
+    // TODO : API Key 검증
 
     // 1. 기존 POI 및 일정 전체 삭제
     await this.workspaceService.clearAllPois(workspaceId);


### PR DESCRIPTION
1. `clearAllPois` 워크스페이스의 모든 POI와 일정을 삭제 
  -  AI가 자동 일정 생성 시 기존 POI들 다 delete 하는 로직 (임시로 간단히)
2. `createAiScheduleBatch` AI 에이전트가 생성한 여행 코스를 일괄로 POI 일정에 추가 

<img width="1111" height="585" alt="image" src="https://github.com/user-attachments/assets/ccce5c65-a9ba-4120-8f0a-3ed01e5b1724" />
